### PR TITLE
feat: add jpms definition for `annotations`

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>@BugPattern annotation</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone annotations</name>
@@ -49,9 +49,39 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
           <compilerArgs combine.self="override" />
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java9</id>
+            <configuration>
+              <source>9</source>
+              <target>9</target>
+              <release>9</release>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module com.google.errorprone.annotation {
+  requires java.base;
+  requires java.compiler;
+}

--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone check api</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone library</name>

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>Documentation tool for generating Error Prone bugpattern documentation</name>

--- a/docgen_processor/pom.xml
+++ b/docgen_processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>JSR-269 annotation processor for @BugPattern annotation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>Error Prone parent POM</name>
   <groupId>com.google.errorprone</groupId>
   <artifactId>error_prone_parent</artifactId>
-  <version>HEAD-SNAPSHOT</version>
+  <version>1.0-HEAD-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <description>Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.</description>
@@ -204,6 +204,16 @@
             <exclude>**/testdata/**</exclude>
           </testExcludes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <arg>-Xlint:-options</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>error_prone_parent</artifactId>
         <groupId>com.google.errorprone</groupId>
-        <version>HEAD-SNAPSHOT</version>
+        <version>1.0-HEAD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone test helpers</name>

--- a/type_annotations/pom.xml
+++ b/type_annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone type annotations</name>


### PR DESCRIPTION
- feat: add `module-info` to `annotations` module
- feat: ship `annotations` as a `Multi-Release` JAR
- feat: support `1.8` through latest JDK for `annotations` module
- fix: `HEAD-SNAPSHOT` → `1.0-HEAD-SNAPSHOT`, because of a Maven Compiler Plugin issue precluding use as a module version[0]

[0]: https://issues.apache.org/jira/browse/MCOMPILER-579